### PR TITLE
Use simple strings for e2ee and allow for users to type in a custom passphrase

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@livekit/components-react": "1.1.7",
+    "@livekit/components-react": "1.1.8",
     "@livekit/components-styles": "1.0.6",
     "livekit-client": "1.13.2",
     "livekit-server-sdk": "1.2.6",

--- a/pages/custom/index.tsx
+++ b/pages/custom/index.tsx
@@ -28,6 +28,8 @@ export default function CustomRoomConnection() {
     return {
       publishDefaults: {
         videoSimulcastLayers: [VideoPresets.h540, VideoPresets.h216],
+        red: false,
+        dtx: false,
       },
       adaptiveStream: { pixelDensity: 'screen' },
       dynacast: true,

--- a/pages/custom/index.tsx
+++ b/pages/custom/index.tsx
@@ -11,26 +11,18 @@ import { useRouter } from 'next/router';
 import { DebugMode } from '../../lib/Debug';
 import { decodePassphrase } from '../../lib/client-utils';
 import { useMemo } from 'react';
-import dynamic from 'next/dynamic';
-
-const PreJoinNoSSR = dynamic(
-  async () => {
-    return (await import('@livekit/components-react')).PreJoin;
-  },
-  { ssr: false },
-);
 
 export default function CustomRoomConnection() {
   const router = useRouter();
   const { liveKitUrl, token } = router.query;
 
-  const hash = typeof window !== 'undefined' && window.location.hash;
+  const e2eePassphrase = typeof window !== 'undefined' && decodePassphrase(window.location.hash);
   const worker =
     typeof window !== 'undefined' &&
     new Worker(new URL('livekit-client/e2ee-worker', import.meta.url));
   const keyProvider = new ExternalE2EEKeyProvider();
 
-  const e2eeEnabled = !!(hash && worker);
+  const e2eeEnabled = !!(e2eePassphrase && worker);
 
   const roomOptions = useMemo((): RoomOptions => {
     return {
@@ -51,7 +43,7 @@ export default function CustomRoomConnection() {
 
   const room = useMemo(() => new Room(roomOptions), []);
   if (e2eeEnabled) {
-    keyProvider.setKey(decodePassphrase(hash.substring(1)));
+    keyProvider.setKey(e2eePassphrase);
     room.setE2EEEnabled(true);
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,7 @@ function DemoMeetingTab({ label }: { label: string }) {
   return (
     <div className={styles.tabContent}>
       <p style={{ margin: 0 }}>Try LiveKit Meet for free with our live demo project.</p>
-      <div style={{ display: 'flex', gap: '1rem' }}>
+      {/* <div style={{ display: 'flex', gap: '1rem' }}>
         <input
           id="use-e2ee"
           type="checkbox"
@@ -59,7 +59,7 @@ function DemoMeetingTab({ label }: { label: string }) {
           onChange={(ev) => setE2ee(ev.target.checked)}
         ></input>
         <label htmlFor="use-e2ee">Enable end-to-end encryption</label>
-      </div>
+      </div> */}
       <button style={{ marginTop: '1rem' }} className="lk-button" onClick={startMeeting}>
         Start Meeting
       </button>
@@ -103,15 +103,7 @@ function CustomConnectionTab({ label }: { label: string }) {
         rows={9}
         style={{ padding: '1px 2px', fontSize: 'inherit', lineHeight: 'inherit' }}
       />
-      <div style={{ display: 'flex', gap: '1rem' }}>
-        <input
-          id="use-e2ee"
-          type="checkbox"
-          checked={e2ee}
-          onChange={(ev) => setE2ee(ev.target.checked)}
-        ></input>
-        <label htmlFor="use-e2ee">Enable end-to-end encryption</label>
-      </div>
+
       <hr
         style={{ width: '100%', borderColor: 'rgba(255, 255, 255, 0.15)', marginBlock: '1rem' }}
       />

--- a/pages/rooms/[name].tsx
+++ b/pages/rooms/[name].tsx
@@ -46,9 +46,6 @@ const Home: NextPage = () => {
 
   function handlePreJoinSubmit(values: LocalUserChoices) {
     if (values.e2ee) {
-      if (values.sharedPassphrase === '') {
-        values.sharedPassphrase = randomString(64);
-      }
       location.hash = encodePassphrase(values.sharedPassphrase);
     }
     setPreJoinChoices(values);
@@ -78,7 +75,7 @@ const Home: NextPage = () => {
                 videoEnabled: true,
                 audioEnabled: true,
                 e2ee: !!e2eePassphrase,
-                sharedPassphrase: e2eePassphrase ? e2eePassphrase : undefined,
+                sharedPassphrase: e2eePassphrase || randomString(64),
               }}
               onSubmit={handlePreJoinSubmit}
               showE2EEOptions={true}

--- a/pages/rooms/[name].tsx
+++ b/pages/rooms/[name].tsx
@@ -25,6 +25,7 @@ import { decodePassphrase, useServerUrl } from '../../lib/client-utils';
 const Home: NextPage = () => {
   const router = useRouter();
   const { name: roomName } = router.query;
+  const [e2ee, setE2ee] = useState(false);
 
   const [preJoinChoices, setPreJoinChoices] = useState<LocalUserChoices | undefined>(undefined);
   return (
@@ -45,6 +46,21 @@ const Home: NextPage = () => {
           ></ActiveRoom>
         ) : (
           <div style={{ display: 'grid', placeItems: 'center', height: '100%' }}>
+            <div style={{ display: 'flex', gap: '1rem' }}>
+              <input
+                id="use-e2ee"
+                type="checkbox"
+                checked={e2ee}
+                onChange={(ev) => setE2ee(ev.target.checked)}
+              ></input>
+              <label htmlFor="use-e2ee">Enable end-to-end encryption</label>
+              {e2ee && (
+                <>
+                  <input id="passphrase" type="text" />{' '}
+                  <label htmlFor="passphrase">Pass phrase</label>
+                </>
+              )}
+            </div>
             <PreJoin
               onError={(err) => console.log('error while setting up prejoin', err)}
               defaults={{
@@ -100,6 +116,8 @@ const ActiveRoom = ({ roomName, userChoices, onLeave }: ActiveRoomProps) => {
         resolution: hq === 'true' ? VideoPresets.h2160 : VideoPresets.h720,
       },
       publishDefaults: {
+        red: false,
+        dtx: false,
         videoSimulcastLayers:
           hq === 'true'
             ? [VideoPresets.h1080, VideoPresets.h720]

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,10 +101,10 @@
     loglevel "^1.8.1"
     rxjs "^7.8.0"
 
-"@livekit/components-react@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@livekit/components-react/-/components-react-1.1.7.tgz#f861350dc0df80fb3f027efa6a1706b9b203923e"
-  integrity sha512-wAOtzetPYMPrE6aA+ABzmLQA57IkvFC+qJiuvSWumbtzVmUZTaD56Y9T2d4F7/zwki3npbUQuABZmFaiMKChpg==
+"@livekit/components-react@1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@livekit/components-react/-/components-react-1.1.8.tgz#34f67a6646bcd5c44d87d3fed5be5010b297f111"
+  integrity sha512-Ljlcqkgg7IqdQIDr7/ViEsL8GZkmSkoMC38hz3CkCcmHP+e8U4+4be2C2feiHb4hHw+tLd1DPuElyEWuTeiQKQ==
   dependencies:
     "@livekit/components-core" "0.6.15"
     "@react-hook/latest" "^1.0.3"


### PR DESCRIPTION
This PR makes interoperability with other livekit examples easier, as it's using the same string based shared key type. 
Previously meet was using random uints, which is not (yet) compatible with other implementations. 