### PR TITLE
Fix missing background color

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,6 +4,7 @@
 
 html {
   color-scheme: dark;
+  background-color: #111;
 }
 
 html,


### PR DESCRIPTION
On Firefox, the background used the default Firefox color palette, which was a black with a hint of red. This PR sets the background to avoid inconsistencies between browsers.