### PR TITLE
Save user choices to localstorage

### DIFF
--- a/lib/local-storage.ts
+++ b/lib/local-storage.ts
@@ -1,0 +1,23 @@
+import { LocalUserChoices } from '@livekit/components-react';
+
+const LOCAL_STORAGE_KEY = 'livekit_meet';
+
+type LocalStorageData = {
+  userChoices: LocalUserChoices;
+  autoJoinRoom: boolean;
+};
+
+export function getLocalStorageData(): LocalStorageData | undefined {
+  if (typeof localStorage === 'undefined') {
+    return undefined;
+  }
+  const data = localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (!data) {
+    return undefined;
+  }
+  return JSON.parse(data);
+}
+
+export function setLocalStorageData(data: LocalStorageData) {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(data));
+}

--- a/lib/local-storage.ts
+++ b/lib/local-storage.ts
@@ -21,3 +21,10 @@ export function getLocalStorageData(): LocalStorageData | undefined {
 export function setLocalStorageData(data: LocalStorageData) {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(data));
 }
+
+export function setLocalStorageAutoJoin(autoJoin: boolean) {
+  const data = getLocalStorageData();
+  if (!data) return;
+  data.autoJoinRoom = autoJoin;
+  setLocalStorageData(data);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import React, { ReactElement, useState } from 'react';
 import styles from '../styles/Home.module.css';
 import { encodePassphrase, generateRoomId, randomString } from '../lib/client-utils';
+import { getLocalStorageData, setLocalStorageAutoJoin } from '../lib/local-storage';
 
 interface TabsProps {
   children: ReactElement[];
@@ -138,6 +139,7 @@ export const getServerSideProps: GetServerSideProps<{ tabIndex: number }> = asyn
 };
 
 const Home = ({ tabIndex }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const [autoJoinRoom, setAutoJoinRoom] = useState(getLocalStorageData()?.autoJoinRoom ?? false);
   const router = useRouter();
   function onTabSelected(index: number) {
     const tab = index === 1 ? 'custom' : 'demo';
@@ -164,6 +166,18 @@ const Home = ({ tabIndex }: InferGetServerSidePropsType<typeof getServerSideProp
           <DemoMeetingTab label="Demo" />
           <CustomConnectionTab label="Custom" />
         </Tabs>
+        {autoJoinRoom && (
+          <button
+            className={'lk-button ' + styles.autoJoinButton}
+            onClick={() => {
+              setLocalStorageAutoJoin(false);
+              setAutoJoinRoom(false);
+            }}
+            style={{ opacity: 0.5, background: '' }}
+          >
+            Stop auto-joining rooms
+          </button>
+        )}
       </main>
       <footer data-lk-theme="default">
         Hosted on{' '}

--- a/pages/rooms/[name].tsx
+++ b/pages/rooms/[name].tsx
@@ -89,6 +89,8 @@ const Home: NextPage = () => {
                   audioEnabled: preJoinChoices?.audioEnabled ?? true,
                   e2ee: !!e2eePassphrase,
                   sharedPassphrase: e2eePassphrase || randomString(64),
+                  videoDeviceId: preJoinChoices?.videoDeviceId ?? undefined,
+                  audioDeviceId: preJoinChoices?.audioDeviceId ?? undefined,
                 }}
                 onSubmit={handlePreJoinSubmit}
                 showE2EEOptions={true}


### PR DESCRIPTION
This PR adds the ability to save settings such as preferred video/audio device, username, and whether to join a room directly without the prejoin step.

I added a toggle to automatically join the next time:
<img width="651" alt="image" src="https://github.com/livekit-examples/meet/assets/11357413/efeb21b6-8b4a-42a3-9ce0-08c21d97b9ce">


To disable auto-join, I added this button, which only appears when auto-join is enabled:
<img width="918" alt="image" src="https://github.com/livekit-examples/meet/assets/11357413/5f7ec570-9164-42b3-9a6a-b23ef4d2f203">
