### PR TITLE
Add optional datadog log ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,6 @@ LIVEKIT_URL=wss://my-livekit-project.livekit.cloud
 
 ## PUBLIC
 NEXT_PUBLIC_LK_TOKEN_ENDPOINT=/api/token
-
 NEXT_PUBLIC_SHOW_SETTINGS_MENU=true
+# NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=client-token
+# NEXT_PUBLIC_DATADOG_SITE=datadog-site

--- a/lib/Debug.tsx
+++ b/lib/Debug.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { useRoomContext } from '@livekit/components-react';
-import { setLogLevel, getLogger, LogLevel, RemoteTrackPublication } from 'livekit-client';
+import { setLogLevel, LogLevel, RemoteTrackPublication, setLogExtension } from 'livekit-client';
 import { tinykeys } from 'tinykeys';
+import { datadogLogs } from '@datadog/browser-logs';
+
 import styles from '../styles/Debug.module.css';
 
 export const useDebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
@@ -9,8 +11,35 @@ export const useDebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
 
   React.useEffect(() => {
     setLogLevel(logLevel ?? 'debug');
-    // @ts-ignore
-    setLogLevel('debug', 'lk-e2ee');
+
+    if (process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN && process.env.NEXT_PUBLIC_DATADOG_SITE) {
+      console.log('setting up datadog logs');
+      datadogLogs.init({
+        clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN,
+        site: process.env.NEXT_PUBLIC_DATADOG_SITE,
+        forwardErrorsToLogs: true,
+        sessionSampleRate: 100,
+      });
+
+      setLogExtension((level, msg, context) => {
+        switch (level) {
+          case LogLevel.debug:
+            datadogLogs.logger.debug(msg, context);
+            break;
+          case LogLevel.info:
+            datadogLogs.logger.info(msg, context);
+            break;
+          case LogLevel.warn:
+            datadogLogs.logger.warn(msg, context);
+            break;
+          case LogLevel.error:
+            datadogLogs.logger.error(msg, context);
+            break;
+          default:
+            break;
+        }
+      });
+    }
 
     // @ts-expect-error
     window.__lk_room = room;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@datadog/browser-logs": "^5.10.0",
     "@livekit/components-react": "2.0.2",
     "@livekit/components-styles": "1.0.10",
     "@livekit/noise-filter": "^0.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@datadog/browser-logs':
+    specifier: ^5.10.0
+    version: 5.10.0
   '@livekit/components-react':
     specifier: 2.0.2
     version: 2.0.2(livekit-client@2.0.4)(react-dom@18.2.0)(react@18.2.0)(tslib@2.6.2)
@@ -75,6 +78,21 @@ packages:
 
   /@bufbuild/protobuf@1.4.2:
     resolution: {integrity: sha512-JyEH8Z+OD5Sc2opSg86qMHn1EM1Sa+zj/Tc0ovxdwk56ByVNONJSabuCUbLQp+eKN3rWNfrho0X+3SEqEPXIow==}
+    dev: false
+
+  /@datadog/browser-core@5.10.0:
+    resolution: {integrity: sha512-fHTay/sPuh7tuGnXhnOkjMUuWewmkNJPlZOf+aVgUKPpv3uHYusl7j8l+YO2QUl86b1wtw487xpEVrlxsPA0aA==}
+    dev: false
+
+  /@datadog/browser-logs@5.10.0:
+    resolution: {integrity: sha512-MjFjN9yv++EyVBUKfmL+Jp364+jP+tHNisvEHhQIkTrZ2GZ7Iy2NaC/tfPMfrcL9k0Fr8QOLEPP0tnwY+TCh/w==}
+    peerDependencies:
+      '@datadog/browser-rum': 5.10.0
+    peerDependenciesMeta:
+      '@datadog/browser-rum':
+        optional: true
+    dependencies:
+      '@datadog/browser-core': 5.10.0
     dev: false
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.56.0):


### PR DESCRIPTION
only activated if env vars are set
```bash
NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=client-token
NEXT_PUBLIC_DATADOG_SITE=datadog-site
```

needs https://github.com/livekit/client-sdk-js/pull/1061 to work reliably