### PR TITLE
Correct LiveKit Cloud hyperlink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <br>
 
-LiveKit Meet is an open source video conferencing app built on [LiveKit Components](https://github.com/livekit/components-js), [LiveKit Cloud](https://livekit.io/cloud), and Next.js. It's been completely redesigned from the ground up using our new components library.
+LiveKit Meet is an open source video conferencing app built on [LiveKit Components](https://github.com/livekit/components-js), [LiveKit](https://livekit.io/) Cloud, and Next.js. It's been completely redesigned from the ground up using our new components library.
 
 ![LiveKit Meet screenshot](./.github/assets/livekit-meet.jpg)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <br>
 
-LiveKit Meet is an open source video conferencing app built on [LiveKit Components](https://github.com/livekit/components-js), [LiveKit](https://livekit.io/) Cloud, and Next.js. It's been completely redesigned from the ground up using our new components library.
+LiveKit Meet is an open source video conferencing app built on [LiveKit Components](https://github.com/livekit/components-js), [LiveKit Cloud](https://cloud.livekit.io/), and Next.js. It's been completely redesigned from the ground up using our new components library.
 
 ![LiveKit Meet screenshot](./.github/assets/livekit-meet.jpg)
 


### PR DESCRIPTION
https://livekit.io/cloud hyperlinked here redirects to the main page, proposing updating the link to https://cloud.livekit.io/