### PR TITLE
feat: add common keyboard shortcuts

### DIFF
--- a/app/custom/VideoConferenceClientImpl.tsx
+++ b/app/custom/VideoConferenceClientImpl.tsx
@@ -13,6 +13,7 @@ import {
 import { DebugMode } from '@/lib/Debug';
 import { useEffect, useMemo } from 'react';
 import { decodePassphrase } from '@/lib/client-utils';
+import { KeyboardShortcuts } from '@/lib/KeyboardShortcuts';
 import { SettingsMenu } from '@/lib/SettingsMenu';
 
 export function VideoConferenceClientImpl(props: {
@@ -39,9 +40,9 @@ export function VideoConferenceClientImpl(props: {
       dynacast: true,
       e2ee: e2eeEnabled
         ? {
-            keyProvider,
-            worker,
-          }
+          keyProvider,
+          worker,
+        }
         : undefined,
     };
   }, []);
@@ -69,6 +70,7 @@ export function VideoConferenceClientImpl(props: {
   return (
     <div className="lk-room-container">
       <RoomContext.Provider value={room}>
+        <KeyboardShortcuts />
         <VideoConference
           chatMessageFormatter={formatChatMessageLinks}
           SettingsComponent={

--- a/app/custom/VideoConferenceClientImpl.tsx
+++ b/app/custom/VideoConferenceClientImpl.tsx
@@ -40,9 +40,9 @@ export function VideoConferenceClientImpl(props: {
       dynacast: true,
       e2ee: e2eeEnabled
         ? {
-          keyProvider,
-          worker,
-        }
+            keyProvider,
+            worker,
+          }
         : undefined,
     };
   }, []);

--- a/app/rooms/[roomName]/PageClientImpl.tsx
+++ b/app/rooms/[roomName]/PageClientImpl.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import React from 'react';
 import { decodePassphrase } from '@/lib/client-utils';
 import { DebugMode } from '@/lib/Debug';
+import { KeyboardShortcuts } from '@/lib/KeyboardShortcuts';
 import { RecordingIndicator } from '@/lib/RecordingIndicator';
 import { SettingsMenu } from '@/lib/SettingsMenu';
 import { ConnectionDetails } from '@/lib/types';
@@ -23,7 +25,6 @@ import {
   RoomEvent,
 } from 'livekit-client';
 import { useRouter } from 'next/navigation';
-import React from 'react';
 
 const CONN_DETAILS_ENDPOINT =
   process.env.NEXT_PUBLIC_CONN_DETAILS_ENDPOINT ?? '/api/connection-details';
@@ -128,9 +129,9 @@ function VideoConferenceComponent(props: {
       dynacast: true,
       e2ee: e2eeEnabled
         ? {
-            keyProvider,
-            worker,
-          }
+          keyProvider,
+          worker,
+        }
         : undefined,
     };
   }, [props.userChoices, props.options.hq, props.options.codec]);
@@ -213,6 +214,7 @@ function VideoConferenceComponent(props: {
   return (
     <div className="lk-room-container">
       <RoomContext.Provider value={room}>
+        <KeyboardShortcuts />
         <VideoConference
           chatMessageFormatter={formatChatMessageLinks}
           SettingsComponent={SHOW_SETTINGS_MENU ? SettingsMenu : undefined}

--- a/app/rooms/[roomName]/PageClientImpl.tsx
+++ b/app/rooms/[roomName]/PageClientImpl.tsx
@@ -129,9 +129,9 @@ function VideoConferenceComponent(props: {
       dynacast: true,
       e2ee: e2eeEnabled
         ? {
-          keyProvider,
-          worker,
-        }
+            keyProvider,
+            worker,
+          }
         : undefined,
     };
   }, [props.userChoices, props.options.hq, props.options.codec]);

--- a/lib/CameraSettings.tsx
+++ b/lib/CameraSettings.tsx
@@ -25,8 +25,8 @@ export function CameraSettings() {
     (cameraTrack as LocalTrackPublication)?.track?.getProcessor()?.name === 'background-blur'
       ? 'blur'
       : (cameraTrack as LocalTrackPublication)?.track?.getProcessor()?.name === 'virtual-background'
-      ? 'image'
-      : 'none',
+        ? 'image'
+        : 'none',
   );
 
   const [virtualBackgroundImagePath, setVirtualBackgroundImagePath] = React.useState<string | null>(

--- a/lib/KeyboardShortcuts.tsx
+++ b/lib/KeyboardShortcuts.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+import { Track } from 'livekit-client';
+import { useLocalParticipant, useTrackToggle } from '@livekit/components-react';
+
+export function KeyboardShortcuts() {
+  const _ = useLocalParticipant();
+  const { toggle: toggleMic, enabled: micEnabled } = useTrackToggle({ source: Track.Source.Microphone });
+  const { toggle: toggleCamera, enabled: cameraEnabled } = useTrackToggle({ source: Track.Source.Camera });
+
+  React.useEffect(() => {
+    function handleShortcut(event: KeyboardEvent) {
+      // Toggle microphone: Cmd/Ctrl-Shift-A
+      if (toggleMic && event.key === 'A' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        toggleMic(!micEnabled, true);
+      }
+
+      // Toggle camera: Cmd/Ctrl-Shift-V
+      if (event.key === 'V' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        toggleCamera(!cameraEnabled, true);
+      }
+    }
+
+    window.addEventListener('keydown', handleShortcut);
+    return () => window.removeEventListener('keydown', handleShortcut);
+  }, [
+    toggleMic, micEnabled,
+    toggleCamera, cameraEnabled,
+  ]);
+
+  return null;
+}

--- a/lib/KeyboardShortcuts.tsx
+++ b/lib/KeyboardShortcuts.tsx
@@ -2,34 +2,30 @@
 
 import React from 'react';
 import { Track } from 'livekit-client';
-import { useLocalParticipant, useTrackToggle } from '@livekit/components-react';
+import { useTrackToggle } from '@livekit/components-react';
 
 export function KeyboardShortcuts() {
-  const _ = useLocalParticipant();
-  const { toggle: toggleMic, enabled: micEnabled } = useTrackToggle({ source: Track.Source.Microphone });
-  const { toggle: toggleCamera, enabled: cameraEnabled } = useTrackToggle({ source: Track.Source.Camera });
+  const { toggle: toggleMic } = useTrackToggle({ source: Track.Source.Microphone });
+  const { toggle: toggleCamera } = useTrackToggle({ source: Track.Source.Camera });
 
   React.useEffect(() => {
     function handleShortcut(event: KeyboardEvent) {
       // Toggle microphone: Cmd/Ctrl-Shift-A
       if (toggleMic && event.key === 'A' && (event.ctrlKey || event.metaKey)) {
         event.preventDefault();
-        toggleMic(!micEnabled, true);
+        toggleMic();
       }
 
       // Toggle camera: Cmd/Ctrl-Shift-V
       if (event.key === 'V' && (event.ctrlKey || event.metaKey)) {
         event.preventDefault();
-        toggleCamera(!cameraEnabled, true);
+        toggleCamera();
       }
     }
 
     window.addEventListener('keydown', handleShortcut);
     return () => window.removeEventListener('keydown', handleShortcut);
-  }, [
-    toggleMic, micEnabled,
-    toggleCamera, cameraEnabled,
-  ]);
+  }, [toggleMic, toggleCamera]);
 
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:fix": "next lint --fix",
+    "format:check": "prettier --check \"**/*.{ts,tsx,md,json}\"",
+    "format:write": "prettier --write \"**/*.{ts,tsx,md,json}\""
   },
   "dependencies": {
     "@datadog/browser-logs": "^5.23.3",


### PR DESCRIPTION
Adds keyboard shortcuts to toggle local participant microphone (<kbd>⌘-Shift-A</kbd> / <kbd>Ctrl-Shift-A</kbd>) and camera (<kbd>⌘-Shift-V</kbd> / <kbd>Ctrl-Shift-V</kbd>) tracks. These shortcuts are the same as [Zoom's defaults](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0067050).

I would also have added a chat toggle (<kbd>⌘-Shift-H</kbd> / <kbd>Ctrl-Shift-H</kbd>) but it needs to be inside the `LayoutContext` to work. Maybe we can accept children in some prefabs to allow context-dependent components to be injected.