### PR TITLE
Add cross origin headers for shared memory usage

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,23 @@ const nextConfig = {
 
     return config;
   },
+  headers: async () => {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin',
+          },
+          {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'credentialless',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
setting these enables shared memory usage between main thread and workers, should yield performance improvements for things like krisp