### PR TITLE
chore(ci): tag deployment versions

### DIFF
--- a/.github/workflows/sync-to-production.yaml
+++ b/.github/workflows/sync-to-production.yaml
@@ -1,9 +1,7 @@
 name: Sync main to sandbox-production
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -31,3 +29,13 @@ jobs:
           git checkout sandbox-production || git checkout -b sandbox-production
           git merge --strategy-option theirs main
           git push origin sandbox-production
+
+      - name: Tag the deployment
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Increment version from previous tag of format vX
+          VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//' | awk -F. -v OFS=. '{$NF++;print}')
+          git tag -a "v$VERSION" -m "Deploy v$VERSION to production"
+          git push origin "v$VERSION"


### PR DESCRIPTION
https://linear.app/livekit/issue/DPRO-506/add-production-safeguards-to-sandbox-template-repos

Tags deployments with `v#` on merging to production branch